### PR TITLE
fix bug when evaluating on nas201

### DIFF
--- a/evoxbench/benchmarks/nb201.py
+++ b/evoxbench/benchmarks/nb201.py
@@ -99,7 +99,7 @@ class NASBench201Evaluator(Evaluator):
 
         if objs is None:
             objs = self.objs
-        objs = set(objs.split('&'))
+        objs = objs.split('&')
         batch_stats = []
         infos = {result.phenotype: result for result in NASBench201Result.objects.filter(phenotype__in=archs)}
         for arch in archs:


### PR DESCRIPTION
use 'list' instead of 'set' when getting the list of objectives to keep the order unchanged.